### PR TITLE
Update metadata.json for 49

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,6 +5,6 @@
   "url": "https://www.github.com/celiopy/auto-adwaita-colors",
   "settings-schema": "org.gnome.shell.extensions.auto-adwaita-colors",
   "shell-version": [
-    "47", "48"
+    "47", "48", "49"
   ]
 }


### PR DESCRIPTION
Update the metadata to support Gnome 49